### PR TITLE
Add config options for watchdog and PoGo killer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,9 @@
   <component name="ChangeListManager">
     <list default="true" id="6b4a635f-a516-4cfa-ab35-1d9c8cf24331" name="Changes" comment="Added module to repo">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/OomAdjusterer/META-INF/com/google/android/update-binary" beforeDir="false" afterPath="$PROJECT_DIR$/OomAdjusterer/META-INF/com/google/android/update-binary" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/OomAdjusterer/META-INF/com/google/android/updater-script" beforeDir="false" afterPath="$PROJECT_DIR$/OomAdjusterer/META-INF/com/google/android/updater-script" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/OomAdjusterer/config.json" beforeDir="false" afterPath="$PROJECT_DIR$/OomAdjusterer/config.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/OomAdjusterer/module.prop" beforeDir="false" afterPath="$PROJECT_DIR$/OomAdjusterer/module.prop" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/OomAdjusterer/service.sh" beforeDir="false" afterPath="$PROJECT_DIR$/OomAdjusterer/service.sh" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -60,6 +61,8 @@
     <setting file="file://$USER_HOME$/AppData/Local/Google/AndroidStudio2023.3/device-explorer/OnePlus IN2013/_/system_ext/etc/build_flags.json" root0="SKIP_INSPECTION" />
     <setting file="file://$USER_HOME$/AppData/Local/Google/AndroidStudio2023.3/device-explorer/OnePlus IN2013/_/system_ext/etc/pixelworks_apps.xml" root0="SKIP_INSPECTION" />
     <setting file="file://$USER_HOME$/AppData/Local/Google/AndroidStudio2023.3/device-explorer/OnePlus IN2013/_/system_ext/etc/spn-conf.xml" root0="SKIP_INSPECTION" />
+    <setting file="file://$USER_HOME$/AppData/Local/Google/AndroidStudio2023.3/device-explorer/Xiaomi 21081111RG/_/data/adb/modules/oom_adjuster/oom_adjuster.log" root0="SKIP_INSPECTION" />
+    <setting file="file://$USER_HOME$/AppData/Local/Google/AndroidStudio2023.3/device-explorer/Xiaomi 21081111RG/_/storage/sdcard0/zram_optimizer.log" root0="SKIP_INSPECTION" />
   </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
@@ -72,21 +75,21 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.cidr.known.project.marker": "true",
-    "RunOnceActivity.readMode.enableVisualFormatting": "true",
-    "ScreenRecorder.SavePath": "C:\\Users\\pontu\\Desktop\\Polygon\\polygonX",
-    "cf.first.check.clang-format": "false",
-    "cidr.known.project.marker": "true",
-    "com.google.services.firebase.aqiPopupShown": "true",
-    "git-widget-placeholder": "update",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/Users/pontu/Desktop/MagiskModule/OomAdjusterer-hotfix/OomAdjusterer_v8.371.zip"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;ScreenRecorder.SavePath&quot;: &quot;C:\\Users\\pontu\\Desktop\\Polygon\\polygonX&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;com.google.services.firebase.aqiPopupShown&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;update&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/pontu/Desktop/Polygon/polygonX&quot;
   }
-}]]></component>
+}</component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 9.1
+- Configurable features: Enable/disable watchdog and phantom_fix.sh via config.json
+- Customizable thresholds: Adjust Pokémon GO Memory killer values in config.json
+- Config location: /data/adb/modules/oom_adjuster/config.json
+
 Version 9
 Update for texture heavy events.
 - Pokémon GO Memory Killer, Automatically kills PoGo when memory usage exceeds thresholds (95% system RAM or 2800MB PoGo usage)

--- a/OomAdjusterer/config.json
+++ b/OomAdjusterer/config.json
@@ -1,5 +1,12 @@
 {
   "protected_apps": [
     "com.evermorelabs.polygonx"
-  ]
+  ],
+  "enable_phantom_fix": false,
+  "enable_watchdog": false,
+  "pogo_memory_killer": {
+    "enabled": true,
+    "system_memory_threshold": 95,
+    "pogo_memory_threshold_mb": 3200
+  }
 }

--- a/OomAdjusterer/module.prop
+++ b/OomAdjusterer/module.prop
@@ -1,7 +1,7 @@
 id=oom_adjuster
 name=OOM Adjuster
-version=v9
-versionCode=9
+version=v9.1
+versionCode=91
 author=zwajton
 description=Adjusts OOM scores for specific apps to prevent killing.
 updateJson=https://raw.githubusercontent.com/zwajton/OomAdjuster/main/update.json

--- a/OomAdjusterer/service.sh
+++ b/OomAdjusterer/service.sh
@@ -25,35 +25,75 @@ log() {
 
 # Load config values
 load_config() {
+    # Default values
+    protected_apps="com.nianticlabs.pokemongo com.evermorelabs.polygonx"
+    enable_phantom_fix="false"
+    enable_watchdog="false"
+    pause_on_pid_change="true"
+    pause_time=10
+    
+    # PoGo killer defaults
+    KILL_POGO_ENABLED="true"
+    SYSTEM_MEMORY_THRESHOLD=95
+    POGO_MEMORY_THRESHOLD=3000
+
     if [ -f "$CONFIG" ]; then
         log "Loading config from $CONFIG"
         
-        # Load protected apps - more robust parsing
+        # Load protected apps
         protected_apps=$(grep -A 20 '"protected_apps"' "$CONFIG" | grep -o '"[^"]*"' | grep -v '"protected_apps"' | tr -d '"' | tr '\n' ' ')
         
-        # Debug: log what was loaded
-        log "Raw protected apps from config: '$protected_apps'"
+        # Load enable_phantom_fix
+        if grep -q '"enable_phantom_fix":\s*true' "$CONFIG"; then
+            enable_phantom_fix="true"
+            log "phantom_fix enabled in config"
+        fi
         
-        # Set default values
-        pause_on_pid_change="true"
-        pause_time=10
+        # Load enable_watchdog
+        if grep -q '"enable_watchdog":\s*true' "$CONFIG"; then
+            enable_watchdog="true"
+            log "watchdog enabled in config"
+        fi
+        
+        # Load PoGo killer settings
+        if grep -q '"pogo_memory_killer"' "$CONFIG"; then
+            # Check if enabled
+            if grep -q '"enabled":\s*false' "$CONFIG"; then
+                KILL_POGO_ENABLED="false"
+                log "PoGo memory killer disabled in config"
+            fi
+            
+            # Load system memory threshold
+            sys_thresh=$(grep -o '"system_memory_threshold":\s*[0-9]*' "$CONFIG" | grep -o '[0-9]*$')
+            if [ -n "$sys_thresh" ]; then
+                SYSTEM_MEMORY_THRESHOLD="$sys_thresh"
+                log "Custom system threshold: ${SYSTEM_MEMORY_THRESHOLD}%"
+            fi
+            
+            # Load PoGo memory threshold
+            pogo_thresh=$(grep -o '"pogo_memory_threshold_mb":\s*[0-9]*' "$CONFIG" | grep -o '[0-9]*$')
+            if [ -n "$pogo_thresh" ]; then
+                POGO_MEMORY_THRESHOLD="$pogo_thresh"
+                log "Custom PoGo threshold: ${POGO_MEMORY_THRESHOLD}MB"
+            fi
+        fi
         
     else
-        log "Config file not found at $CONFIG"
-        # Default values
-        protected_apps="com.nianticlabs.pokemongo com.evermorelabs.polygonx"
-        pause_on_pid_change="true"
-        pause_time=10
+        log "Config file not found at $CONFIG - using defaults"
     fi
     
     log "Final protected apps: '$protected_apps'"
+    log "Settings - phantom_fix: $enable_phantom_fix, watchdog: $enable_watchdog"
+    log "PoGo killer - enabled: $KILL_POGO_ENABLED, system: ${SYSTEM_MEMORY_THRESHOLD}%, pogo: ${POGO_MEMORY_THRESHOLD}MB"
 }
 
-# Launch phantom fix
-#if [ -f "$MODDIR/phantom_fix.sh" ]; then
-#    sh "$MODDIR/phantom_fix.sh" &
-#    log "Phantom fix started"
-#fi
+# Launch phantom fix (only if enabled in config)
+if [ "$enable_phantom_fix" = "true" ] && [ -f "$MODDIR/phantom_fix.sh" ]; then
+    sh "$MODDIR/phantom_fix.sh" &
+    log "Phantom fix started (enabled in config)"
+elif [ "$enable_phantom_fix" = "true" ] && [ ! -f "$MODDIR/phantom_fix.sh" ]; then
+    log "WARNING: phantom_fix enabled but phantom_fix.sh not found"
+fi
 
 # Load config
 load_config
@@ -130,15 +170,16 @@ prev_pid_pogo=""
     done
 ) &
 # ==========================
-# PolygonX Watchdog with Dual Cache Clear & PoGo Kill on LMKD Recovery
+# PolygonX Watchdog (only if enabled in config)
 # ==========================
+if [ "$enable_watchdog" = "true" ]; then
 (
     APP_PKG="com.evermorelabs.polygonx"
     POGO_PKG="com.nianticlabs.pokemongo"
     CHECK_INTERVAL=35
     RESTART_DELAY=15
 
-    log "PolygonX watchdog started with dual cache clear & PoGo kill on LMKD recovery."
+    log "PolygonX watchdog started (enabled in config)"
 
     while true; do
         if ! pidof "$APP_PKG" > /dev/null; then
@@ -209,6 +250,9 @@ prev_pid_pogo=""
         sleep "$CHECK_INTERVAL"
     done
 ) &
+else
+    log "PolygonX watchdog disabled in config"
+fi
 
 # ==========================
 # Swap Space Monitor & Protector
@@ -326,7 +370,7 @@ prev_pid_pogo=""
         sleep 60
     done
 ) &
-# --------------------------------------------------
+
 # LRU memory deprioritizer loop with 80% RAM usage threshold
 (
     while true; do
@@ -334,15 +378,15 @@ prev_pid_pogo=""
         mem_avail_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
         mem_used_kb=$((mem_total_kb - mem_avail_kb))
         mem_usage_percent=$(( (mem_used_kb * 100) / mem_total_kb ))
-# --------------------------------------------------
+
         if [ "$mem_usage_percent" -ge 75 ]; then
             log "Memory usage at ${mem_usage_percent}%. Running LRU deprioritization."
-# --------------------------------------------------
+
             dumpsys activity lru | grep -E 'Proc #[0-9]+:' | while read -r line; do
                 pkg=$(echo "$line" | sed -n 's/.*ProcessRecord{[^ ]* [^ ]* \([^ ]*\)\/[^ ]*} .*/\1/p')
                 proc_state=$(echo "$line" | grep -oE 'procState=[0-9]+' | cut -d= -f2)
                 pid=$(echo "$line" | grep -oE 'pid=[0-9]+' | cut -d= -f2)
-# --------------------------------------------------
+
                 if [ -n "$proc_state" ] && [ -n "$pid" ] && [ -n "$pkg" ]; then
                     if [ "$proc_state" -eq 19 ]; then
                         # Processes with a procstate of 19 will be force stopped
@@ -358,24 +402,20 @@ prev_pid_pogo=""
         else
             log "Memory usage at ${mem_usage_percent}%. Skipping LRU scan."
         fi
-# --------------------------------------------------
+
         sleep 60
     done
 ) &
-# --------------------------------------------------
+
 # ==========================
-# Pokémon GO Memory Killer
+# Pokémon GO Memory Killer (only if enabled)
 # ==========================
+if [ "$KILL_POGO_ENABLED" = "true" ]; then
 (
-    POGO_PKG="com.nianticlabs.pokemongo"
-    SYSTEM_MEMORY_THRESHOLD=95    # Kill at 95% system RAM
-    POGO_MEMORY_THRESHOLD=2800    # Kill at 2800MB PoGo usage
-    CHECK_INTERVAL=10
-    
     log "PoGo memory killer started (System: ${SYSTEM_MEMORY_THRESHOLD}%, PoGo: ${POGO_MEMORY_THRESHOLD}MB)"
 
     while true; do
-        pogo_pid=$(pidof "$POGO_PKG")
+        pogo_pid=$(pidof "com.nianticlabs.pokemongo")
         if [ -n "$pogo_pid" ]; then
             # Calculate system memory usage percentage
             mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
@@ -389,7 +429,7 @@ prev_pid_pogo=""
             
             log "Memory: Total=${mem_usage_percent}%, PoGo=${pogo_memory_mb}MB"
             
-            # Kill if system memory > 95% OR PoGo using > 2800MB
+            # Kill if system memory > threshold OR PoGo using > threshold
             if [ "$mem_usage_percent" -ge "$SYSTEM_MEMORY_THRESHOLD" ] || [ "$pogo_memory_mb" -ge "$POGO_MEMORY_THRESHOLD" ]; then
                 log "KILLING PoGo - System RAM: ${mem_usage_percent}%, PoGo RAM: ${pogo_memory_mb}MB"
                 
@@ -397,21 +437,24 @@ prev_pid_pogo=""
                 cmd package trim-caches com.nianticlabs.pokemongo >> "$LOG_FILE" 2>&1
                 
                 # Kill all PoGo processes aggressively
-                pgrep -f "$POGO_PKG" | while read -r pid; do
+                pgrep -f "com.nianticlabs.pokemongo" | while read -r pid; do
                     kill -9 "$pid" 2>/dev/null
                 done
                 
                 # Force stop any remnants
-                am force-stop "$POGO_PKG" 2>/dev/null
+                am force-stop "com.nianticlabs.pokemongo" 2>/dev/null
                 
                 # Free system memory
                 echo 3 > /proc/sys/vm/drop_caches
                 
-                log "SUCCESS: PoGo killed and memory freed - PolygonX will restart it"
+                log "SUCCESS: PoGo killed and memory freed"
             fi
         fi
-        sleep "$CHECK_INTERVAL"
+        sleep 10
     done
 ) &
+else
+    log "PoGo memory killer disabled in config"
+fi
 log "OOM adjustment, cache cleaner, and watchdog started in background."
 exit 0

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "9",
-  "versionCode": 9,
-  "zipUrl": "https://github.com/zwajton/OomAdjuster/releases/download/v9/oom_adjuster_v9.zip",
+  "version": "9.1",
+  "versionCode": 91,
+  "zipUrl": "https://github.com/zwajton/OomAdjuster/releases/download/v9.1/oom_adjuster_v9.1.zip",
   "changelog": "https://raw.githubusercontent.com/zwajton/OomAdjuster/main/CHANGELOG.md"
 }


### PR DESCRIPTION
Introduces configurable features in config.json to enable/disable watchdog and phantom_fix.sh, and customize Pokémon GO memory killer thresholds. Updates service.sh to respect these config options, and bumps version to 9.1 in module.prop and update.json. CHANGELOG.md documents the new features and config location.